### PR TITLE
Update gem version to 2.1.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,30 +1,30 @@
 PATH
   remote: .
   specs:
-    gql_serializer (2.0.0)
+    gql_serializer (2.1.1)
       activerecord (>= 5.2, < 6.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.0.3.4)
-      activesupport (= 6.0.3.4)
-    activerecord (6.0.3.4)
-      activemodel (= 6.0.3.4)
-      activesupport (= 6.0.3.4)
-    activesupport (6.0.3.4)
+    activemodel (6.0.3.5)
+      activesupport (= 6.0.3.5)
+    activerecord (6.0.3.5)
+      activemodel (= 6.0.3.5)
+      activesupport (= 6.0.3.5)
+    activesupport (6.0.3.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
       zeitwerk (~> 2.2, >= 2.2.2)
     coderay (1.1.3)
-    concurrent-ruby (1.1.7)
+    concurrent-ruby (1.1.8)
     diff-lcs (1.4.4)
-    i18n (1.8.5)
+    i18n (1.8.9)
       concurrent-ruby (~> 1.0)
     method_source (1.0.0)
-    minitest (5.14.2)
+    minitest (5.14.4)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)

--- a/lib/gql_serializer/version.rb
+++ b/lib/gql_serializer/version.rb
@@ -1,3 +1,3 @@
 module GqlSerializer
-  VERSION = "2.0.0"
+  VERSION = "2.1.1"
 end


### PR DESCRIPTION
This update fixes an issue with the gem version not being updated in the previous release. As a result, some users would see the following error if attempting to update to the latest version:

```shell
Could not find gem 'gql_serializer (~> 2.1.0)' in https://github.com/TheDro/gql_serializer.git (at master@da9871f).
The source contains 'gql_serializer' at: 2.0.0
```